### PR TITLE
Modifying sauce.js to not repeat results

### DIFF
--- a/plugins/sauce.js
+++ b/plugins/sauce.js
@@ -10,6 +10,7 @@ module.exports = function (client) {
 			var $ = cheerio.load(data);
 			var results = $('.resulttablecontent');
 			var found = false;
+			var repeatList = [];
 			for (var i = 0; i < results.length && i < 3; ++i) {
 				var result = results.eq(i);
 
@@ -19,8 +20,9 @@ module.exports = function (client) {
 				var title = $('.resulttitle', result).text();
 
 				var link = $('.resultcontentcolumn a', result).eq(0).attr('href');
-				if (!link) continue;
+				if (!link || repeatList.indexOf(link) !== -1) continue;
 
+				repeatList.push(link);
 				found = true;
 				cb({
 					title: title,


### PR DESCRIPTION
When saucenao.com lists multiple sources (gotten from boorus), the bot lists them all. [This](http://saucenao.com/search.php?db=999&url=http://cdn.awwni.me/mek8.jpg) for example makes the bot go:

> 僕と( ◕ ‿‿ ◕ )契約して！ [96%] - http://www.pixiv.net/member_illust.php?mode=medium&illust_id=16709496
> Creator: nekoyanagi moyo [95%] - http://www.pixiv.net/member_illust.php?mode=medium&illust_id=16709496
> Creator: nekoyanagi moyo [92%] - http://www.pixiv.net/member_illust.php?mode=medium&illust_id=16709496

Another possible solution would be to output the booru pages themselves, rather than their source.
