### PR TITLE
Major rewrite of nyaa.js to make the searches use the rss

### DIFF
--- a/plugins/nyaa.js
+++ b/plugins/nyaa.js
@@ -1,86 +1,213 @@
 ﻿var filesize = require('filesize');
 var nyaa = require("nyaatorrents");
+var xml2js = require('xml2js');
+var request = require('request');
 var utils = require('../utils');
 
 module.exports = function (client) {
 
-	var nyaaDefault = new nyaa('http://www.nyaa.se');
-	var nyaaSukebei = new nyaa('http://sukebei.nyaa.se');
+	var defaultBaseURL = 'http://www.nyaa.se/';
+	var sukebeiBaseURL = 'http://sukebei.nyaa.se/';
 
-	var random = utils.random;
+	function requestAndParse(url, cb) {
+		request.get({ url: url }, function (err, res, body) {
+			if (err) {
+				cb(err);
+				return;
+			}
 
-	function getData(nyu, id, cb) {
-		nyu.get(id, function (err, data) {
-			if (err) return;
-
-			cb(data);
+			var parser = new xml2js.Parser();
+			parser.parseString(body.toString('utf8'), cb);
 		});
 	}
 
-	function postData(channel, data) {
-		var str = data.nsfw ? '\x0304[NSFW]\x03 ' : '';
-		str += data.name + ' - ' + filesize(data.size);
-		str += ' | S: ' + (isNaN(data.seeders) ? '?' : data.seeders);
-		str += ' | L: ' + (isNaN(data.leechers) ? '?' : data.leechers);
-		str += ' | http://' + (data.nsfw ? 'sukebei' : 'www') + '.nyaa.se/?page=view&tid=' + data.id;
-		str += ' | http://' + (data.nsfw ? 'sukebei' : 'www') + '.nyaa.se/?page=download&tid=' + data.id;
+	function editEntryFormat(entry) {
+		var re = /(\d+) seeder\(s\), (\d+) leecher\(s\), (\d+) download\(s\) - (\d+\.?\d* \S+)/
+		var match = re.exec(entry.description);
+		if (!match) return null;
 
-		client.say(channel, str);
+		entry.seeders = match[1];
+		entry.leechers = match[2];
+		entry.downloads = match[3];
+		entry.size = match[4];
+
+		entry.age = Date.now() - new Date(entry.pubDate).getTime();
+
+		return entry;
+	}
+
+	function formatData(data, searchURL) {
+		return utils.format('{0} - {1} | S: {2} | L: {3} | {4} | {5}', data.title, data.size, data.seeders, data.leechers, data.guid, data.link);
+	}
+
+	function getBest(entries) {
+		var seedersWeight = 1;
+		var ageWeight = -1 / 1000 / 60 / 60;
+		// score is # of seeders - age in hours
+		var bestScore = entries[0].seeders * seedersWeight + entries[0].age * ageWeight;
+		var bestEntry = entries[0];
+
+		for (var i = 1; i < entries.length; i++) {
+			var score = entries[i].seeders * seedersWeight + entries[i].age * ageWeight;
+			if (score > bestScore) {
+				bestScore = score;
+				bestEntry = entries[i];
+			}
+		}
+
+		return bestEntry;
 	}
 
 	return {
 		commands: {
 			nyaa: function (from, channel, msg) {
-				nyaaDefault.search({cats: '1_37'/* English-translated anime */, term: msg}, function (err, entries) {
-					if (err) return;
+				if (channel === client.nick) { // if PM
+					channel = from;
+				}
 
-					if (entries.length === 0) {
-						client.say(channel, 'No results for "' + msg + '". Try !nyaan or !nyaall?');
+				msg = msg.trim();
+
+				requestAndParse(defaultBaseURL + '?page=rss&cats=1_37&term=' + encodeURIComponent(msg), function (err, data) {
+					if (err) {
+						client.say(channel, 'No response. Please try again.');
+						return console.error('Error getting data: ' + err);
+					}
+
+					var entries = data.rss.channel[0].item;
+					if (!entries || entries.length === 0) {
+						client.say(channel, 'No results for \'' + msg + '\'. Try !nyaan or !nyaall?');
 						return;
 					}
 
-					getData(nyaaDefault, entries[random(entries.length)].id, postData.bind(undefined, channel));
+					entries.map(editEntryFormat);
+
+					// if the regex in editEntryFormat doesn't match
+					// (although it always should)
+					// we'll get null entries
+					for (var i = 0; i < entries.length; i++) {
+						if (entries[i] === null) {
+							entries.splice(i, 1);
+							i--;
+						}
+					}
+
+					if (entries.length === 0) {
+						client.say(channel, 'Something went wrong... Uhh... try again?');
+						return;
+					}
+
+					var dataString = formatData(getBest(entries));
+
+					client.say(channel, dataString);
+
+					client.notice(from, defaultBaseURL + '?page=search&cats=1_37&term=' + encodeURIComponent(msg));
 				});
 			},
 
 			nyaall: function (from, channel, msg) {
-				nyaaDefault.search({term: msg}, function (err, entries) {
-					if (err) return;
+				msg = msg.trim();
 
-					if (entries.length === 0) {
-						client.say(channel, 'No results for "' + msg + '". Try !nyaan?');
+				requestAndParse(defaultBaseURL + '?page=rss&term=' + encodeURIComponent(msg), function (err, data) {
+					if (err) {
+						client.say(channel, 'No response. Please try again.');
+						return console.error('Error getting data: ' + err);
+					}
+
+					var entries = data.rss.channel[0].item;
+					if (!entries || entries.length === 0) {
+						client.say(channel, 'No results for \'' + msg + '\'. Try !nyaan?');
 						return;
 					}
-					
-					getData(nyaaDefault, entries[random(entries.length)].id, postData.bind(undefined, channel));
+
+					entries.map(editEntryFormat);
+
+					// if the regex in editEntryFormat doesn't match
+					// (although it always should)
+					// we'll get null entries
+					for (var i = 0; i < entries.length; i++) {
+						if (entries[i] === null) {
+							entries.splice(i, 1);
+							i--;
+						}
+					}
+
+					if (entries.length === 0) {
+						client.say(channel, 'Something went wrong... Uhh... try again?');
+						return;
+					}
+
+					var dataString = formatData(getBest(entries));
+
+					client.say(channel, dataString);
+
+					client.notice(from, defaultBaseURL + '?page=search&term=' + encodeURIComponent(msg));
 				});
 			},
 
 			nyaan: function (from, channel, msg) {
-				nyaaSukebei.search({term: msg}, function (err, entries) {
-					if (err) return;
+				msg = msg.trim();
 
-					if (entries.length === 0) {
-						client.say(channel, 'No results for "' + msg + '". Try !nyaan?');
+				requestAndParse(sukebeiBaseURL + '?page=rss&term=' + encodeURIComponent(msg), function (err, data) {
+					if (err) {
+						client.say(channel, 'No response. Please try again.');
+						return console.error('Error getting data: ' + err);
+					}
+
+					var entries = data.rss.channel[0].item;
+					if (!entries || entries.length === 0) {
+						client.say(channel, 'No results for \'' + msg + '\'. Try !nyaa or !nyaall?');
 						return;
 					}
 
-					getData(nyaaSukebei, entries[random(entries.length)].id, function (data) {
-						data.nsfw = true;
-						postData(channel, data);
-					});
+					entries.map(editEntryFormat);
+
+					// if the regex in editEntryFormat doesn't match
+					// (although it always should)
+					// we'll get null entries
+					for (var i = 0; i < entries.length; i++) {
+						if (entries[i] === null) {
+							entries.splice(i, 1);
+							i--;
+						}
+					}
+
+					if (entries.length === 0) {
+						client.say(channel, 'Something went wrong... Uhh... try again?');
+						return;
+					}
+
+					var dataString = '\x0304[NSFW]\x03 ' + formatData(getBest(entries));
+
+					client.say(channel, dataString);
+
+					client.notice(from, sukebeiBaseURL + '?page=search&term=' + encodeURIComponent(msg));
 				});
 			}
 		},
 
 		messageHandler: function (from, channel, message) {
+			if (channel[0] !== '#') return; // we don't care about PMs
+
 			var re = /http:\/\/(sukebei|www)\.nyaa\.(eu|se)\/\?page=(view|download)&tid=(\d+)/gi;
 			var match;
+			var getData = function(nyu, id, cb) {
+				new nyaa(nyu).get(id, function (err, data) {
+					if (err) return;
+
+					cb(data);
+				});
+			};
 
 			while (match = re.exec(message)) {
-				getData(match[1] === 'sukebei' ? nyaaSukebei : nyaaDefault, match[4], function (nsfw, data) {
-					data.nsfw = nsfw;
-					postData(channel, data);
+				getData(match[1] === 'sukebei' ? sukebeiBaseURL : defaultBaseURL, match[4], function (nsfw, data) {
+					var dataString = (nsfw ? '\x0304[NSFW]\x03 ' : '') + formatData({
+						title: data.name,
+						size: filesize(data.size),
+						guid: (nsfw ? sukebeiBaseURL : defaultBaseURL) + '?page=view&tid=' + data.id,
+						link: (nsfw ? sukebeiBaseURL : defaultBaseURL) + '?page=download&tid=' + data.id,
+					});
+
+					client.say(channel, dataString);
 				}.bind(undefined, match[1] === 'sukebei'));
 			}
 		}


### PR DESCRIPTION
This lets us compare entries by their seeders and age (which isn't available in a search).
The !nyaa, !nyaan, !nyaall commands no longer return a random entry, but pick one based on number of seeders and age. The current score formula is <number of seeders> - <age in hours> which does okay, but maybe something more biased towards small age would be better. Also, could maybe log the age, so that really old torrents are still in the game?
