### PR TITLE
Fixing a crash when !pixiv is not passed search terms

### DIFF
--- a/plugins/pixiv.js
+++ b/plugins/pixiv.js
@@ -52,6 +52,7 @@ module.exports = function (client) {
 	return {
 		commands: {
 			pixiv: function (from, channel, message) {
+				if (message.trim() === ' ') return;
 				searchPixiv(message, postPixiv.bind(null, channel, message));
 			}
 		},


### PR DESCRIPTION
Line #44's `arr === null && term` evaluates to false due to `term` (`''`) evaluating to false. Subsequently line #47 crashes with `TypeError: Cannot read property '4' of null`.
