### PR TITLE
Alert when params for !choice is empty ( "Nothing to choose from :(" )

### DIFF
--- a/plugins/choice.js
+++ b/plugins/choice.js
@@ -9,6 +9,12 @@ module.exports = function (client, channelName) {
 	return {
 		commands: {
 			choice: function (from, message) {
+				
+				if(!message) {
+					client.say(channel, "Nothing to choose from :(");
+					return;
+				}
+				
 				csv().from.string(message, { delimiter: ' ' }).to.array(function (data) {
 					data = data[0];
 


### PR DESCRIPTION
When I say "!choice" (without any params), bot responds by "<nickname>: undefined".

This commit fixes this by denying and alerting when such case is made. 
