### PR TITLE
Adding missing `var` keyword

### DIFF
--- a/plugins/reddit.js
+++ b/plugins/reddit.js
@@ -57,7 +57,7 @@ module.exports = function (client) {
 								post.title = '\x0304' + post.title + '\x04';
 							}
 
-							msg = (post.over_18 || srData.nsfl ? '[\x0304NSFW\x03] ' : '')
+							var msg = (post.over_18 || srData.nsfl ? '[\x0304NSFW\x03] ' : '')
 							+ '[\x03' + color + post.subreddit + '\x03]'
 							+ ' [' + post.author + '] '
 							+ ent.decode(post.title)


### PR DESCRIPTION
It was removed in the latest PR by me (>.>), which reintroduced the bug we had before using `foreach`.
