### PR TITLE
Fixing two bugs that crash the bot.

### DIFF
--- a/plugins/mal.js
+++ b/plugins/mal.js
@@ -50,7 +50,10 @@ module.exports = function (client) {
 								if (err) {
 									deferred.reject(err);
 								} else {
-									deferred.resolve(JSON.parse(data));
+									var data = JSON.parse(data);
+									data.id = match[1];
+
+									deferred.resolve(data);
 								}
 							});
 						} else {
@@ -63,7 +66,11 @@ module.exports = function (client) {
 						var data = datas[i];
 						if (!data) continue;
 
-						cb(data);
+						if (data.error) {
+							cb(data.id);
+						} else {
+							cb(data);
+						}
 					}
 
 				}).done();

--- a/plugins/mal.js
+++ b/plugins/mal.js
@@ -35,8 +35,10 @@ module.exports = function (client) {
 							cb(data);
 						}
 					});
-				} else {
+				} else if (next) {
 					next();
+				} else {
+					cb(null);
 				}
 			} else {
 				Q.all(


### PR DESCRIPTION
The first one occurs because the `next` parameter in the google callback is null on the last (or only) page of results.

The second one occurs because there is no check for errors from mal-api.com and it crashes when `ent.decode` is called with a null (more generally, non-null) value.
