### PR TITLE
Removed the link to pixiv in MoeBot's response since it's a response to that same link

### DIFF
--- a/plugins/pixiv.js
+++ b/plugins/pixiv.js
@@ -45,7 +45,7 @@ module.exports = function (client) {
 			client.say(channel, 'Sorry, nothing found for ' + term);
 		} else {
 			client.emit('commands:image', channel, { image: 'http://i1.pixiv.net/img' + arr[4] + '/img/' + arr[24] + '/' + arr[0] + '.' + arr[2] });
-			client.say(channel, (arr[26] === '1' ? '\x0304NSFW\x03 - ' : '') + arr[3] + ' [' + arr[5] + '] - http://pixiv.net/member_illust.php?mode=medium&illust_id=' + arr[0]);
+			client.say(channel, (arr[26] === '1' ? '\x0304NSFW\x03 - ' : '') + arr[3] + ' [' + arr[5] + ']');
 		}
 	}
 


### PR DESCRIPTION
Some users in the chat complained that MoeBot was unnecessarily spammy when it comes to Pixiv links.  Since the link is posted by them in the first place, having MoeBot link it as well seems superfluous. Further optimizations could be made by not constructing the link in the first place, but it was left in for possible future use.
-Alpacalex
