### PR TITLE
Improving the wikipedia plugin a bit

### DIFF
--- a/plugins/wikipedia.js
+++ b/plugins/wikipedia.js
@@ -30,13 +30,13 @@ function parseLinks(str) {
 
 function queryGoogle(query, cb) {
 	google.resultsPerPage = 1;
-
-	google('site:en.wikipedia.org ' + query, function (err, next, links) {
+	var url='site:en.wikipedia.org ' + query;
+	google(url, function (err, next, links) {
 		if (err) {
 			if (err.status) {
 				cb(new Error('Something went wrong while searching on Google: ' + err.status + ': ' + http['STATUS_CODES'][status]), null);
 			} else {
-				cb(new Error('Something went wrong while searching on Google (' + (err.code || '-') + ')'), null);
+				cb(new Error('Something went wrong while searching on Google: ' + err.message), null);
 			}
 
 			return;

--- a/plugins/wikipedia.js
+++ b/plugins/wikipedia.js
@@ -61,14 +61,17 @@ function queryGoogle(query, cb) {
 }
 
 function queryWikipedia(title, cb) {
+	// see https://en.wikipedia.org/w/api.php for detailed usage information
 	var url = 'https://en.wikipedia.org/w/api.php?'
-		+ 'format=json&'
-		+ 'action=query&'
-		+ 'prop=extracts&'
-		+ 'explaintext=1&'
-		+ 'exsentences=1&'
-		+ 'redirects=1&'
-		+ 'titles=' + encodeURIComponent(title);
+		+ 'format=json&'							// The format of the output
+		+ 'action=query&'							// What action you would like to perform
+		+ 'prop=extracts&'							// Which properties to get for the titles/revisions/pageids
+		+ 'redirects=1&'							// Automatically resolve redirects
+		+ 'exintro=1&'								// Return only content before the first section (get just the lead)
+		+ 'explaintext=1&'							// Return extracts as plaintext instead of limited HTML
+		+ 'titles=' + encodeURIComponent(title);	// A list of titles to work on; Separate values with '|'
+
+	console.log('Querying ' + url);
 
 	request.get(url, function(err, resp, body) {
 		if (err) {
@@ -106,6 +109,15 @@ function format(data, titleIfEmpty) {
 	// if we have a page without (plain) text or without a lead section do nothing
 	if (extract.length === 0 || extract.match(/^==.+==$/)) {
 		return titleIfEmpty ? '\x0312' + title + '\x03' : '';
+	}
+	
+	// replace newlines with `; `, unless preceded by punctuation
+	extract = extract.replace(/([^.,;:!?])\n+/g, '$1; ');
+	extract = extract.replace(/\n+/g, ' ');
+
+	// if over 200 characters, truncate and add elipsis
+	if (extract.length > 200) {
+		extract = extract.substring(0, 200) + '...';
 	}
 
 	// if the title is contained within the extract, we want to color it

--- a/plugins/wikipedia.js
+++ b/plugins/wikipedia.js
@@ -93,6 +93,11 @@ function queryWikipedia(title, cb) {
 }
 
 function format(data, titleIfEmpty) {
+	var iw = data.query.interwiki;
+	if (iw !== undefined) {
+		return titleIfEmpty ? '\x0312' + iw[0].title + '\x03' : '';
+	}
+
 	var pages = data.query.pages;
 	var id = Object.keys(pages)[0];
 	var title = pages[id].title;


### PR DESCRIPTION
Made interwiki links (like https://en.wikipedia.org/wiki/Wiktionary:Ball) at the very least post the link, instead of just failing.

Judging sentence ends by punctuation is too prone to errors (for example, instead of "King Kong vs. Godzilla (キングコング対ゴジラ Kingu Kongu Tai Gojira?) is a 1962 Japanese Science fiction Kaiju film produced by Toho Studios." we'd get "King Kong vs.") and oftentimes a single sentence is not enough.
Now we're getting the whole lead, and truncating it if over 200 characters.
