### PR TITLE
Failed uploads now only return one single message

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"main": "bot.js",
 	"dependencies": {
+		"async": "x",
 		"redwrap": "x",
 		"irc": "git+https://github.com/Sebmaster/node-irc.git",
 		"youtube-feeds": "x",


### PR DESCRIPTION
I'm using the async library because it works a lot better than that annoyingly complex for-loop.
