### PR TITLE
Fixing crash on bad google response

### DIFF
--- a/plugins/wikipedia.js
+++ b/plugins/wikipedia.js
@@ -38,7 +38,7 @@ function queryGoogle(query, cb) {
 	google(url, function (err, next, links) {
 		if (err) {
 			if (err.status) {
-				cb(new Error('Something went wrong while searching on Google: ' + err.status + ': ' + http['STATUS_CODES'][status]), null);
+				cb(new Error('Something went wrong while searching on Google: ' + err.status + ': ' + http['STATUS_CODES'][err.status]), null);
 			} else {
 				cb(new Error('Something went wrong while searching on Google: ' + err.message), null);
 			}


### PR DESCRIPTION
Due to attempting to access the undefined var `status` instead of `err.status`, the bot would crash on non-2*\* response from Google.
