### PR TITLE
Major expand of the Soundcloud plugin to allow reporting of playlist URLs as well as searching through Google

### DIFF
--- a/plugins/soundcloud.js
+++ b/plugins/soundcloud.js
@@ -28,14 +28,14 @@ function parseLinks(str) {
 		// we don't care about it, so we just drop it
 		strArr[i] = strArr[i].split('?')[0];
 		
-		if (match = songRegex.exec(strArr[i])) {
+		if (match = strArr[i].match(songRegex)) {
 			matches.push({
 				type: 'track',
 				url: match[0],
 				artist: match[1],
 				title: match[2]
 			});
-		} else if (match = setRegex.exec(strArr[i])) {
+		} else if (match = strArr[i].match(setRegex)) {
 			matches.push({
 				type: 'playlist',
 				url: match[0],
@@ -44,7 +44,8 @@ function parseLinks(str) {
 			});
 		}
 	}
-
+	
+	
 	return matches;
 }
 


### PR DESCRIPTION
The Soundcloud API lets us treat tracks and playlists with almost no consideration of their difference. The only significant ones are the regex matching and the report message format.

I experimented with the search function provided in SC's API, however it is greatly inferior to just using Google, requiring exact wording of track or playlist names and sometimes even then not giving the expected result.
