### PR TITLE
Fixing video duration parsing

### DIFF
--- a/plugins/youtube.js
+++ b/plugins/youtube.js
@@ -92,8 +92,8 @@ function stringifyVideo(video) {
 }
 
 function parseIso8601Duration(str) {
-	// format: PT#D#H#M#S, where # is a number and each of #D, #H, #M, and #S are optional
-	var re = /PT(?:(\d+)D)?(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/;
+	// format: P#DT#H#M#S, where # is a number and each of #D, #H, #M, and #S are optional
+	var re = /P(?:(\d+)D)?T(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/;
 	var match = str.match(re);
 	
 	var days = parseInt(match[1]) || 0;


### PR DESCRIPTION
Turns out the format is `P<date>T<time>` and not `PT<date><time>`.

Also, turns out >1-day duration videos exist.